### PR TITLE
Crashes, Slug and Admin loging fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,17 @@ In order to run this project you need to have already installed:
 ### How to run the server locally
 Run the website with the following commands:
 
-- `make deps`: install project dependencies.
-- `make ops`: starts the database.
-- `make clean_init_db`: fills the database with random data.
-- `make dev`: starts the web server.
+```
+make deps
+make ops
+```
 
+```
+make clean_init_db
+make dev
+```
 
-
+- `make deps`: install project dependencies
+- `make ops`: starts the database
+- `make clean_init_db`: fills the database with random data
+- `make dev`: starts the web server

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,3 +17,15 @@ config :elephant_in_the_room, ElephantInTheRoom.Repo,
   database: "elephant_in_the_room_test",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
+
+##
+## Cookies & Auth
+##
+config :elephant_in_the_room, ElephantInTheRoomWeb.Endpoint,
+secret_key_base: "nzdAWjDdDu8NoQlv0Hhk3Q08LtZ/fLPUoyTR5j+wTN1kPPiGEDRCoKmI4Ftl65V1",
+signing_salt: "H8osk+zCmp8zhgxNjtoTuSDfj5T2rRV80uqhF6mOhEQF",
+encryption_salt: "LL0FHuwYWDy5uYsadZPSrYzdZdrUmmApt07Nl1sQ1wA2"
+
+config :elephant_in_the_room, ElephantInTheRoom.Auth.Guardian,
+issuer: "elephant_in_the_room",
+secret_key: "UipYx0z54wtvC8EZ0bavPWkaCk5gFvu/9caWXb/fwiALISfAVDrvlIq5JPGMuE8J"

--- a/lib/elephant_in_the_room/sites/post.ex
+++ b/lib/elephant_in_the_room/sites/post.ex
@@ -40,7 +40,7 @@ defmodule ElephantInTheRoom.Sites.Post do
 
   @doc false
   def changeset(%Post{} = post, attrs) do
-    new_attrs = Map.put(attrs, "image", image_hash_name(attrs["image"]))
+    new_attrs = image_hash_name_in_attrs(attrs)
 
     post
     |> cast(new_attrs, [:title, :content, :slug, :abstract, :site_id, :author_id, :cover])
@@ -50,8 +50,19 @@ defmodule ElephantInTheRoom.Sites.Post do
     |> validate_required([:title, :content, :site_id, :image, :cover])
     |> put_rendered_content
     |> put_slugified_title
-    |> unique_constraint(:slug, name: :slug_unique_index)
   end
+
+  def get_required(%Post{image: current_image}, attrs) do
+    required = [:title, :content, :site_id, :cover]
+    case current_image != nil do
+      true -> required
+      false -> [:image | required]
+    end
+  end
+
+  def image_hash_name_in_attrs(%{"image" => image} = attrs), do:
+    %{attrs | "image" => image_hash_name(image)}
+  def image_hash_name_in_attrs(attrs), do: attrs
 
   def image_hash_name(%Plug.Upload{filename: filename} = upload) do
     extension =
@@ -79,11 +90,11 @@ defmodule ElephantInTheRoom.Sites.Post do
     |> validate_length(:rendered_content, min: 1)
   end
 
-  defp calculate_occurrences(slug, site_id) do
-    site = Sites.get_site!(site_id)
-
-    site.posts
-    |> Enum.count(fn post -> post.slug == slug end)
+  defp calculate_occurrences(n, slug, suffix) do
+    case Repo.get_by(Post, slug: slug <> suffix) do
+      nil -> n
+      %Post{} -> calculate_occurrences(n + 1, slug, "-#{n + 1}")
+    end
   end
 
   def put_slugified_title(%Changeset{valid?: valid?} = changeset)
@@ -92,16 +103,17 @@ defmodule ElephantInTheRoom.Sites.Post do
   end
 
   def put_slugified_title(%Changeset{} = changeset) do
-    site_id = get_field(changeset, :site_id)
     slug = get_field(changeset, :slug)
 
     if slug == nil || String.length(slug) == 0 do
       slug = get_field(changeset, :title) |> Sites.to_slug()
-    end
 
-    case calculate_occurrences(slug, site_id) do
-      0 -> put_change(changeset, :slug, slug)
-      n -> put_change(changeset, :slug, slug <> "-#{n}")
+      case calculate_occurrences(0, slug, "") do
+        0 -> put_change(changeset, :slug, slug)
+        n -> put_change(changeset, :slug, slug <> "-#{n}")
+      end
+    else
+      changeset
     end
   end
 

--- a/lib/elephant_in_the_room/sites/post.ex
+++ b/lib/elephant_in_the_room/sites/post.ex
@@ -90,8 +90,7 @@ defmodule ElephantInTheRoom.Sites.Post do
   end
 
   def generate_markdown(input) do
-    {:safe, safe_input} = Phoenix.HTML.html_escape(input)
-    Cmark.to_html(safe_input)
+    Cmark.to_html(input, [:safe])
   end
 
   def parse_categories(params) do

--- a/lib/elephant_in_the_room/sites/post.ex
+++ b/lib/elephant_in_the_room/sites/post.ex
@@ -50,18 +50,21 @@ defmodule ElephantInTheRoom.Sites.Post do
     |> validate_required([:title, :content, :site_id, :image, :cover])
     |> put_rendered_content
     |> put_slugified_title
+    |> unique_constraint(:slug, name: :slug_unique_index)
   end
 
   def get_required(%Post{image: current_image}, attrs) do
     required = [:title, :content, :site_id, :cover]
+
     case current_image != nil do
       true -> required
       false -> [:image | required]
     end
   end
 
-  def image_hash_name_in_attrs(%{"image" => image} = attrs), do:
-    %{attrs | "image" => image_hash_name(image)}
+  def image_hash_name_in_attrs(%{"image" => image} = attrs),
+    do: %{attrs | "image" => image_hash_name(image)}
+
   def image_hash_name_in_attrs(attrs), do: attrs
 
   def image_hash_name(%Plug.Upload{filename: filename} = upload) do
@@ -90,11 +93,11 @@ defmodule ElephantInTheRoom.Sites.Post do
     |> validate_length(:rendered_content, min: 1)
   end
 
-  defp calculate_occurrences(n, slug, suffix) do
-    case Repo.get_by(Post, slug: slug <> suffix) do
-      nil -> n
-      %Post{} -> calculate_occurrences(n + 1, slug, "-#{n + 1}")
-    end
+  defp calculate_occurrences(slug, site_id) do
+    site = Sites.get_site!(site_id)
+
+    site.posts
+    |> Enum.count(fn post -> post.slug == slug end)
   end
 
   def put_slugified_title(%Changeset{valid?: valid?} = changeset)
@@ -103,17 +106,16 @@ defmodule ElephantInTheRoom.Sites.Post do
   end
 
   def put_slugified_title(%Changeset{} = changeset) do
+    site_id = get_field(changeset, :site_id)
     slug = get_field(changeset, :slug)
 
     if slug == nil || String.length(slug) == 0 do
       slug = get_field(changeset, :title) |> Sites.to_slug()
+    end
 
-      case calculate_occurrences(0, slug, "") do
-        0 -> put_change(changeset, :slug, slug)
-        n -> put_change(changeset, :slug, slug <> "-#{n}")
-      end
-    else
-      changeset
+    case calculate_occurrences(slug, site_id) do
+      0 -> put_change(changeset, :slug, slug)
+      n -> put_change(changeset, :slug, slug <> "-#{n}")
     end
   end
 

--- a/lib/elephant_in_the_room/sites/post.ex
+++ b/lib/elephant_in_the_room/sites/post.ex
@@ -47,6 +47,7 @@ defmodule ElephantInTheRoom.Sites.Post do
     |> validate_required([:title, :content, :site_id])
     |> put_rendered_content
     |> put_slugified_title
+    |> unique_constraint(:slug, name: :slug_unique_index)
   end
 
   def put_rendered_content(%Changeset{valid?: valid?} = changeset)
@@ -62,11 +63,11 @@ defmodule ElephantInTheRoom.Sites.Post do
     |> validate_length(:rendered_content, min: 1)
   end
 
-  defp calculate_occurrences(n, slug, suffix) do
-    case Repo.get_by(Post, slug: slug <> suffix) do
-      nil -> n
-      %Post{} -> calculate_occurrences(n + 1, slug, "-#{n + 1}")
-    end
+  defp calculate_occurrences(slug, site_id) do
+    site = Sites.get_site!(site_id)
+
+    site.posts
+    |> Enum.count(fn post -> post.slug == slug end)
   end
 
   def put_slugified_title(%Changeset{valid?: valid?} = changeset)
@@ -75,17 +76,16 @@ defmodule ElephantInTheRoom.Sites.Post do
   end
 
   def put_slugified_title(%Changeset{} = changeset) do
+    site_id = get_field(changeset, :site_id)
     slug = get_field(changeset, :slug)
 
     if slug == nil || String.length(slug) == 0 do
       slug = get_field(changeset, :title) |> Sites.to_slug()
+    end
 
-      case calculate_occurrences(0, slug, "") do
-        0 -> put_change(changeset, :slug, slug)
-        n -> put_change(changeset, :slug, slug <> "-#{n}")
-      end
-    else
-      changeset
+    case calculate_occurrences(slug, site_id) do
+      0 -> put_change(changeset, :slug, slug)
+      n -> put_change(changeset, :slug, slug <> "-#{n}")
     end
   end
 

--- a/lib/elephant_in_the_room_web/controllers/user_controller.ex
+++ b/lib/elephant_in_the_room_web/controllers/user_controller.ex
@@ -39,7 +39,7 @@ defmodule ElephantInTheRoomWeb.UserController do
       {:ok, _user} ->
         conn
         |> put_flash(:info, "User created successfully.")
-        |> redirect(to: login_path(conn, :index))
+        |> redirect(to: user_path(conn, :index))
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "new.html", changeset: changeset)

--- a/lib/elephant_in_the_room_web/domain_based.ex
+++ b/lib/elephant_in_the_room_web/domain_based.ex
@@ -1,9 +1,12 @@
 defmodule ElephantInTheRoomWeb.DomainBased do
+  use ElephantInTheRoomWeb, :view
   alias Plug.Conn
   
   def is_localhost(%Conn{host: host}) do
     host == "localhost"
   end
+
+  def is_not_localhost(conn), do: !is_localhost(conn)
 
   def get_site_id(%Conn{} = conn, params) do 
     id = if !is_localhost(conn), 
@@ -13,6 +16,21 @@ defmodule ElephantInTheRoomWeb.DomainBased do
       nil -> {:error, :no_site_id}
       id -> {:ok, id}
     end
+  end
+
+  def get_post_public_show_path(conn, post, site) do
+    year = post.inserted_at.year
+    month = post.inserted_at.month
+    day = post.inserted_at.day
+    site_id =
+      case site do
+        nil -> post.site.id
+        _ -> site.id
+      end
+
+    if is_not_localhost(conn),
+      do: post_path(conn, :public_show, year, month, day, post.slug),
+      else: local_post_path(conn, :public_show, site_id, year, month, day, post.slug)
   end
 
 end

--- a/lib/elephant_in_the_room_web/router.ex
+++ b/lib/elephant_in_the_room_web/router.ex
@@ -31,7 +31,6 @@ defmodule ElephantInTheRoomWeb.Router do
     get("/login", LoginController, :index)
     post("/login", LoginController, :login)
     get("/logout", LoginController, :logout)
-    resources("/users", UserController, only: [:new, :create])
     get("/author/:author_id", AuthorController, :public_show)
 
     get("/site/:id", SiteController, :public_show, as: "local_site")
@@ -43,7 +42,7 @@ defmodule ElephantInTheRoomWeb.Router do
       pipe_through([:on_admin_page, :ensure_auth])
       get("/", AdminController, :index)
       resources("/roles", RoleController)
-      resources("/users", UserController, except: [:new, :create])
+      resources("/users", UserController)
       resources("/authors", AuthorController)
 
       resources "/sites", SiteController do
@@ -62,7 +61,6 @@ defmodule ElephantInTheRoomWeb.Router do
     get("/login", LoginController, :index)
     post("/login", LoginController, :login)
     get("/logout", LoginController, :logout)
-    resources("/users", UserController, only: [:new, :create])
     get("/author/:author_id", AuthorController, :public_show)
 
     get("/post/:year/:month/:day/:slug", PostController, :public_show)
@@ -73,7 +71,7 @@ defmodule ElephantInTheRoomWeb.Router do
       pipe_through([:on_admin_page, :ensure_auth])
       get("/", AdminController, :index)
       resources("/roles", RoleController)
-      resources("/users", UserController, except: [:new, :create])
+      resources("/users", UserController)
       resources("/authors", AuthorController)
 
       resources "/sites", SiteController do

--- a/lib/elephant_in_the_room_web/templates/admin/_bottom_pagination.html.eex
+++ b/lib/elephant_in_the_room_web/templates/admin/_bottom_pagination.html.eex
@@ -6,7 +6,7 @@
 
     <%= if pagination_left do %>
       <li>
-        <a href="<%= site_path(@conn, :index, page: @page_number - 1) %>">
+        <a href="<%= assigns.page.(@page_number - 1) %>">
           <span class="uk-margin-small-right" uk-pagination-previous></span>
           Previous
         </a>
@@ -21,7 +21,7 @@
     <%= end %>
     <%= if pagination_right do %>
       <li class="">
-        <a href="<%= site_path(@conn, :index, page: @page_number + 1) %>">
+        <a href="<%= assigns.page.(@page_number + 1) %>">
           Next
           <span class="uk-margin-small-left" uk-pagination-next></span>
         </a>

--- a/lib/elephant_in_the_room_web/templates/layout/_admin.html.eex
+++ b/lib/elephant_in_the_room_web/templates/layout/_admin.html.eex
@@ -14,7 +14,7 @@
     </ul>
     <ul class="uk-navbar-nav admin-nav-options show-only-on-bigger-than-small">
       <li><a href="/">Home</a></li>
-      <li><a href="#">Payments</a></li>
+      <li><%= link "Logout", to: login_path(@conn, :logout) %></li>
     </ul>
   </div>
 
@@ -32,7 +32,7 @@
      class="admin-nav-options small-admin-nav-options" aria-hidden="true" hidden>
   <ul>
     <li><a href="/">Home</a></li>
-    <li><a href="#">Payments</a></li>
+    <li><%= link "Logout", to: login_path(@conn, :logout) %></li>
   </ul>
   <div class="shadow"></div>
 </div>

--- a/lib/elephant_in_the_room_web/templates/layout/_user_options.html.eex
+++ b/lib/elephant_in_the_room_web/templates/layout/_user_options.html.eex
@@ -16,6 +16,17 @@
 <% end %>
 
 <%= case login do %>
+  <% {:ok, _, _} -> %>
+  <li>
+    <%= link to: login_path(@conn, :logout) do %>
+      <i class="fas fa-sign-out-alt"></i>
+      Logout
+    <% end %>
+  </li>
+  <% _ -> %>
+<% end %>
+
+<%= case login do %>
   <% {:ok, _user, :admin} -> %>
   <li>
     <a href="<%= admin_path(@conn, :index) %>">

--- a/lib/elephant_in_the_room_web/templates/login/login.html.eex
+++ b/lib/elephant_in_the_room_web/templates/login/login.html.eex
@@ -43,7 +43,6 @@
 
           <div class="form-group">
             <%= submit "Login", class: "uk-button uk-button-primary" %>
-            <%= link "or register", to: user_path(@conn, :new) %>
           </div>
         </fieldset>
       <% end %>

--- a/lib/elephant_in_the_room_web/templates/post/form.html.eex
+++ b/lib/elephant_in_the_room_web/templates/post/form.html.eex
@@ -1,4 +1,9 @@
 
+<%= if assigns[:post] do %>
+  <%= link "view post", to: ElephantInTheRoomWeb.DomainBased.get_post_public_show_path(@conn, @post, @site),
+        target: "_blank"  %>
+<%= end %>
+
 <%= form_for @changeset, @action, [multipart: true], fn f -> %>
 <fieldset class="uk-fieldset">
 

--- a/lib/elephant_in_the_room_web/templates/post/form.html.eex
+++ b/lib/elephant_in_the_room_web/templates/post/form.html.eex
@@ -80,8 +80,10 @@
 </fieldset>
 <% end %>
 
-<%= link to: site_post_path(@conn, :delete, @site.id, @post.id), 
-        method: :delete, data: [confirm: "Are you sure your want to delete this post?"], 
-        class: "uk-button uk-button-danger uk-width-1-1" do %>
-  <i class="fas fa-trash"></i>
-<% end%>
+<%= if assigns[:post] do %>
+  <%= link to: site_post_path(@conn, :delete, @site.id, @post.id), 
+          method: :delete, data: [confirm: "Are you sure your want to delete this post?"], 
+          class: "uk-button uk-button-danger uk-width-1-1" do %>
+    <i class="fas fa-trash"></i>
+  <% end%>
+<%= end %>

--- a/lib/elephant_in_the_room_web/templates/post/index.html.eex
+++ b/lib/elephant_in_the_room_web/templates/post/index.html.eex
@@ -22,4 +22,4 @@
 </ul>
 
 <%= render ElephantInTheRoomWeb.AdminView,
-      "_bottom_pagination.html", assigns %>
+      "_bottom_pagination.html", Map.put(assigns, :page, &site_post_path(@conn, :index, @site.id, page: &1)) %>

--- a/lib/elephant_in_the_room_web/templates/site/index.html.eex
+++ b/lib/elephant_in_the_room_web/templates/site/index.html.eex
@@ -23,4 +23,4 @@
 </ul>
 
 <%= render ElephantInTheRoomWeb.AdminView,
-      "_bottom_pagination.html", assigns %>
+      "_bottom_pagination.html", Map.put(assigns, :page, &site_path(@conn, :index, page: &1)) %>

--- a/priv/repo/migrations/20180223155619_create_posts.exs
+++ b/priv/repo/migrations/20180223155619_create_posts.exs
@@ -15,6 +15,7 @@ defmodule ElephantInTheRoom.Repo.Migrations.CreatePosts do
       timestamps()
     end
 
+    create(unique_index(:posts, [:slug, :site_id], name: :slug_unique_index))
     create(index(:posts, [:site_id]))
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -13,7 +13,7 @@
 alias ElephantInTheRoom.Auth
 alias ElephantInTheRoom.Auth.Role
 alias ElephantInTheRoom.Repo
-alias ElephantInTheRoom.Sites
+alias ElephantInTheRoom.Auth.User
 
 case Repo.get_by(Role, name: "admin") do
   nil ->
@@ -23,6 +23,7 @@ case Repo.get_by(Role, name: "admin") do
   _admin_role ->
     IO.puts("admin role already created!")
 end
+admin_role_id = Repo.get_by(Role, name: "admin").id
 
 case Repo.get_by(Role, name: "user") do
   nil ->
@@ -33,13 +34,22 @@ case Repo.get_by(Role, name: "user") do
     IO.puts("user role already created!")
 end
 
-# case length(Sites.list_sites()) == 0 do
-#   false ->
-#     # do nothing
-#     IO.puts("No need to create a new site")
+create_admin_user_data = fn () -> 
+  %{
+    username: "admin",
+    password:  to_string(Kernel.trunc(:rand.uniform()*1000000000)),
+    firstname: "admin",
+    lastname: "1",
+    email: "admin@lambdaclass.com",
+    role_id: admin_role_id
+  }
+end
 
-#   true ->
-#     # create a site 
-#     IO.puts("Creating a new site!")
-#     Sites.create_site(%{name: "default site", host: "default-site.com"})
-# end
+if  Repo.get_by(User, id: 1) == nil do
+  admin = create_admin_user_data.()
+  Auth.create_user(admin)
+  inform_str = "user: #{admin.username}\npassword: #{admin.password}\n"
+  file_name = "admin_data.txt"
+  File.write!(file_name, inform_str, [:write])
+  IO.puts("Administration account data is inside #{file_name}, check it for logging")
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -33,13 +33,13 @@ case Repo.get_by(Role, name: "user") do
     IO.puts("user role already created!")
 end
 
-case length(Sites.list_sites()) == 0 do
-  false ->
-    # do nothing
-    IO.puts("No need to create a new site")
+# case length(Sites.list_sites()) == 0 do
+#   false ->
+#     # do nothing
+#     IO.puts("No need to create a new site")
 
-  true ->
-    # create a site 
-    IO.puts("Creating a new site!")
-    Sites.create_site(%{name: "default site", host: "default-site.com"})
-end
+#   true ->
+#     # create a site 
+#     IO.puts("Creating a new site!")
+#     Sites.create_site(%{name: "default site", host: "default-site.com"})
+# end

--- a/test/elephant_in_the_room/sites/post_test.exs
+++ b/test/elephant_in_the_room/sites/post_test.exs
@@ -1,0 +1,16 @@
+defmodule ElephantInTheRoomWeb.SiteControllerTest do
+  use ElephantInTheRoomWeb.ConnCase
+  alias ElephantInTheRoom.Sites.Post
+
+  describe "markdown" do 
+    test "& input" do
+      assert "<p>&amp;</p>\n" = Post.generate_markdown("&")
+    end
+
+    test "unsafe" do
+      assert "<!-- raw HTML omitted -->\n" = Post.generate_markdown("<script>alert(\"hello world!\")</script>")
+    end
+
+  end
+
+end


### PR DESCRIPTION
- Avoid crashing when a post has no author.
- Allow no author in post.
- Avoid showing a blank image when the file name includes a symbol.
- Allow the same slug for multiple sites, i.e.: `site/1/slug_1` and `site/2/slug_1`.
- Prevent any anonymous user for creating an  account, now is part of the administration panel and the first user is generated when `mix ecto.reset`. The user and password is inside `admin_data.txt` in the calling directory.
- Add logout button, remove payment button. 
- Allow post edition without forcing to upload an image if the post already has one.