### PR TITLE
Fix compilation bug in prod environment

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule ElephantInTheRoom.Mixfile do
 
       # markdown
       {:cmark, "~> 0.7"},
-      {:faker, "~> 0.9", only: [:dev, :test]},
+      {:faker, "~> 0.9"},
 
       # pagination
       {:scrivener_ecto, "~> 1.0"},


### PR DESCRIPTION
The problem was that we need to have `faker` not only as a :test and :dev dependency, we need it in :prod too.