### PR TITLE
Post's text improvements

### DIFF
--- a/assets/css/_post.scss
+++ b/assets/css/_post.scss
@@ -43,6 +43,8 @@
       @media all and (max-width:1240px){ font-size: 19px; }
       @media all and (max-width:840px){ font-size: 18px; }
       @media all and (max-width:720px){ font-size: 19px; }
+      margin-top: 0;
+      margin-bottom: 0.4em;
     }
 
     img {

--- a/assets/css/_post.scss
+++ b/assets/css/_post.scss
@@ -35,6 +35,7 @@
 
   .article-content {
     line-height: 1.35;
+    margin-bottom: 5em;
 
     p {
       color: $black;

--- a/assets/css/_post.scss
+++ b/assets/css/_post.scss
@@ -38,6 +38,11 @@
 
     p {
       color: $black;
+      hyphens: none;
+      font-size: 20px;
+      @media all and (max-width:1240px){ font-size: 19px; }
+      @media all and (max-width:840px){ font-size: 18px; }
+      @media all and (max-width:720px){ font-size: 19px; }
     }
 
     img {

--- a/lib/elephant_in_the_room_web/faker/post.ex
+++ b/lib/elephant_in_the_room_web/faker/post.ex
@@ -31,11 +31,15 @@ defmodule ElephantInTheRoomWeb.Faker.Post do
   end
 
   defp generate_content() do
-    [gen_text(50), gen_md_image(), gen_text(40)] |> Enum.join(" ")
+    [gen_text(20), gen_md_image(), gen_text(20)] |> Enum.join("\n\n")
   end
 
-  defp gen_text(length) do
-    Faker.Lorem.paragraph(:rand.uniform(length))
+  defp gen_text(length), do: gen_text(length, :rand.uniform(5))
+  defp gen_text(length, paragraph_count) do
+    paragraphs = for _ <- 0 .. paragraph_count do
+      Faker.Lorem.paragraph(:rand.uniform(length))
+    end
+    Enum.join(paragraphs, "\n\n")
   end
 
   defp gen_md_image() do
@@ -43,6 +47,6 @@ defmodule ElephantInTheRoomWeb.Faker.Post do
     image_content = File.read!(Utils.get_image_path())
 
     {:ok, image} = Sites.create_image(%{name: Ecto.UUID.generate(), binary: image_content})
-    "\n![#{description}](/images/#{image.name})\n"
+    "![#{description}](/images/#{image.name})"
   end
 end

--- a/lib/elephant_in_the_room_web/templates/post/public_show.html.eex
+++ b/lib/elephant_in_the_room_web/templates/post/public_show.html.eex
@@ -50,7 +50,7 @@
   </div>
   <%= render "_social_share.html", assigns %>
 
-  <div class="article-content uk-text-justify">
+  <div class="article-content">
     <%= raw show_content @post %>
   </div>
 


### PR DESCRIPTION
#380 #384 
This PR:
- Removes text justification.
- Creates new lines in the automatic post generation.
- Changes `p` margin. 

## Text
<img width="698" alt="screen shot 2018-07-23 at 2 40 10 pm" src="https://user-images.githubusercontent.com/8556088/43093431-63dd5678-8e86-11e8-8281-3c920c9efe38.png">

## Text + Footer
<img width="771" alt="screen shot 2018-07-23 at 2 40 33 pm" src="https://user-images.githubusercontent.com/8556088/43093490-924971f4-8e86-11e8-94db-ea07d2411e59.png">

