### PR TITLE
Popular redis fix

### DIFF
--- a/lib/elephant_in_the_room/sites/post.ex
+++ b/lib/elephant_in_the_room/sites/post.ex
@@ -212,4 +212,8 @@ defmodule ElephantInTheRoom.Sites.Post do
     post
   end
 
+  def delete_all_popular_entries() do
+    Redix.command(:redix, ["FLUSHDB"])
+  end
+
 end

--- a/lib/elephant_in_the_room/sites/post.ex
+++ b/lib/elephant_in_the_room/sites/post.ex
@@ -206,4 +206,10 @@ defmodule ElephantInTheRoom.Sites.Post do
     Redix.command(:redix, ["ZINCRBY", "site:#{site_id}", 1, post_id])
     post
   end
+
+  def delete_popular_entry(%Post{id: post_id, site_id: site_id} = post) do
+    Redix.command(:redix, ["ZREM", "site:#{site_id}", post_id])
+    post
+  end
+
 end

--- a/lib/elephant_in_the_room/sites/sites.ex
+++ b/lib/elephant_in_the_room/sites/sites.ex
@@ -497,6 +497,7 @@ defmodule ElephantInTheRoom.Sites do
 
   """
   def delete_post(%Post{} = post) do
+    Post.delete_popular_entry(post)
     Repo.delete(post)
   end
 

--- a/priv/repo/data_generator.ex
+++ b/priv/repo/data_generator.ex
@@ -1,5 +1,6 @@
 alias ElephantInTheRoomWeb.Faker, as: ElephantFaker
 
+ElephantInTheRoom.Sites.Post.delete_all_popular_entries()
 config = %{
   sites: 2,
   categories: 4,


### PR DESCRIPTION
This PR:
- Ensures that when a post is deleted it's entry in the redis database is also deleted.
- Flushes all entries in the redis when running the auto generation.