### PR TITLE
Fix post order

### DIFF
--- a/lib/elephant_in_the_room/sites/post.ex
+++ b/lib/elephant_in_the_room/sites/post.ex
@@ -202,11 +202,7 @@ defmodule ElephantInTheRoom.Sites.Post do
 
     Map.put(attrs, "inserted_at", datetime)
   end
-
-  defp parse_date(attrs) do
-    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
-    Map.put(attrs, "inserted_at", now)
-  end
+  defp parse_date(attrs), do: attrs
 
   def increase_views_for_popular_by_1(%Post{id: post_id, site_id: site_id} = post) do
     Redix.command(:redix, ["ZINCRBY", "site:#{site_id}", 1, post_id])

--- a/lib/elephant_in_the_room_web/faker/post.ex
+++ b/lib/elephant_in_the_room_web/faker/post.ex
@@ -13,6 +13,7 @@ defmodule ElephantInTheRoomWeb.Faker.Post do
       "cover" => Utils.get_image_path(),
       "title" => Enum.join(Faker.Lorem.words(7), " "),
       "abstract" => Faker.Lorem.paragraph(10),
+      "inserted_at" => generate_inserted_at(),
       "slug" => ""
     }
   end
@@ -28,6 +29,17 @@ defmodule ElephantInTheRoomWeb.Faker.Post do
   def insert_many(n, attrs \\ %{}) do
     Enum.to_list(1..n)
     |> Enum.map(fn _ -> insert_one(attrs) end)
+  end
+
+  defp generate_inserted_at() do
+    now = NaiveDateTime.utc_now
+    hour = :rand.uniform(23)
+    minute = :rand.uniform(59)
+    second = :rand.uniform(59)
+    case NaiveDateTime.new(now.year, now.month, now.day, hour, minute, second) do
+      {:ok, time} -> time
+      _ -> generate_inserted_at()
+    end
   end
 
   defp generate_content() do

--- a/lib/elephant_in_the_room_web/views/post_view.ex
+++ b/lib/elephant_in_the_room_web/views/post_view.ex
@@ -74,9 +74,6 @@ defmodule ElephantInTheRoomWeb.PostView do
   @one_day_and_few_hours @one_day + 5 * @one_hour
   @two_weeks 1_209_600
 
-  defp format_diff(diff, date) when diff < 0,
-    do: {:date, "el #{date.day}-#{date.month}-#{date.year}"}
-
   defp format_diff(diff, _date) when diff <= @five_minutes, do: {:now, "justo ahora"}
 
   defp format_diff(diff, _date) when diff < @one_hour,


### PR DESCRIPTION
#391 
Previously after changing a post it may change also the position in the landing page, that was because in the automatic generation most of the most had the same time. This PR fixes that making the `inserted_at` at time, a random value.