### PR TITLE
Update landing style

### DIFF
--- a/assets/css/_landing_page.scss
+++ b/assets/css/_landing_page.scss
@@ -10,6 +10,14 @@
   }
 }
 
+%landing-title {
+  hyphens: none;
+  text-transform: capitalize;
+  font-weight: 600;
+  line-height: 21px;
+  font-family: unset;
+}
+
 .post {
   position: relative;
 
@@ -39,7 +47,7 @@
     font-size: 70%;
   }
   .author {
-    font-size: 75%;
+    font-size: 65%;
   }
   .date {
     font-size: 70%;
@@ -88,10 +96,12 @@
   .image {
     float: right;
     width: 80px;
-    height: 80px
+    height: 80px;
+    margin-left: 5px;
   }
   .title {
-    font-size: 85%;
+    @extend %landing-title;
+    font-size: 82%;
     line-height: 1rem;
   }
 
@@ -109,6 +119,7 @@
   }
 
   .title {
+    @extend %landing-title;
     line-height: 1.2;
 
     @media screen and (min-width: 640px) {
@@ -159,8 +170,8 @@
   }
 
   .author {
-    color: #666;
-    font-size: 70%;
+    color: #777;
+    font-size: 65%;
   }
 
 }
@@ -201,8 +212,7 @@
   padding: 10px;
 
   p:first-child {
-    font-family: $title-font;
-    hyphens: none;
+    @extend %landing-title 
   }
   p:nth-child(2) {
     font-size: 80%;

--- a/assets/css/_landing_page.scss
+++ b/assets/css/_landing_page.scss
@@ -81,6 +81,7 @@
     margin-bottom: 0px;
   }
   .title {
+    @extend %landing-title;
     padding: 0;
     font-size: 1.6em;
     line-height: 1em;

--- a/lib/elephant_in_the_room_web/templates/site/_latest.html.eex
+++ b/lib/elephant_in_the_room_web/templates/site/_latest.html.eex
@@ -16,7 +16,7 @@
             <% end %>
           </div>
           <div class="uk-width-expand uk-text-left">
-            <p class="uk-text-uppercase uk-margin-remove-bottom">
+            <p class="uk-margin-remove-bottom">
               <%= link post.title, to: SiteView.show_link_with_date(@conn, post) %>
             </p>
             <p class="uk-margin-small-top">


### PR DESCRIPTION
Fixes:
  - Margin added to the right images to prevent the title touch them.
  - Uppercase avoided in titles #412
![screenshot from 2018-08-02 15-02-57](https://user-images.githubusercontent.com/8556088/43602051-373642ec-9665-11e8-9c21-d7726808f49c.png)
